### PR TITLE
Remove unnecessary `ParametersAcceptorSelector::selectSingle` handling

### DIFF
--- a/src/TypeExtension/MethodCall/ContainerGetReturnTypeExtension.php
+++ b/src/TypeExtension/MethodCall/ContainerGetReturnTypeExtension.php
@@ -38,7 +38,7 @@ final class ContainerGetReturnTypeExtension implements DynamicMethodReturnTypeEx
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): Type {
+    ): ?Type {
         return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
     }
 }

--- a/src/TypeExtension/MethodCall/LaravelContainerMakeTypeExtension.php
+++ b/src/TypeExtension/MethodCall/LaravelContainerMakeTypeExtension.php
@@ -36,7 +36,7 @@ final class LaravelContainerMakeTypeExtension implements DynamicMethodReturnType
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): Type {
+    ): ?Type {
         return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
     }
 }

--- a/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
+++ b/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
@@ -18,10 +18,8 @@ use Symplify\PHPStanExtensions\Exception\ShouldNotHappenException;
 
 final class ClassConstFetchReturnTypeResolver
 {
-    public function resolve(MethodReflection $methodReflection, MethodCall $methodCall): Type
+    public function resolve(MethodReflection $methodReflection, MethodCall $methodCall): ?Type
     {
-        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
-
         if (! isset($methodCall->args[0])) {
             throw new ShouldNotHappenException('Not supported without argument');
         }
@@ -45,6 +43,6 @@ final class ClassConstFetchReturnTypeResolver
             return new ObjectType($className);
         }
 
-        return $returnType;
+        return null;
     }
 }


### PR DESCRIPTION
remove unnecessary use of `ParametersAcceptorSelector::selectSingle` which is deprecated with PHPStan 2.x

analog https://github.com/symplify/phpstan-rules/pull/142