### PR TITLE
Fix "Argument #1 ($string) must be of type string, bool given"

### DIFF
--- a/src/Console/Terminal.php
+++ b/src/Console/Terminal.php
@@ -125,7 +125,7 @@ final class Terminal
         return $info;
     }
 
-    public static function getAnsiconWidth(): ?int
+    private static function getAnsiconWidth(): ?int
     {
         if (!is_string(\getenv('ANSICON'))) {
             return null;


### PR DESCRIPTION
make the test-suite pass on windows

before this PR:

```
$ vendor/bin/phpunit
PHPUnit 10.5.38 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.12
Configuration: C:\dvl\Workspace\phpstan-extensions\phpunit.xml

E....                                                               5 / 5 (100%)

Time: 00:01.020, Memory: 86.00 MB

There was 1 error:

1) Symplify\PHPStanExtensions\Tests\ErrorFormatter\SymplifyErrorFormatterTest::testFormatErrors with data set #0 ('Some message', 1, 1, 1, 'C:\dvl\Workspace\phpstan-exte...rt.txt')
TypeError: trim(): Argument #1 ($string) must be of type string, bool given

C:\dvl\Workspace\phpstan-extensions\src\Console\Terminal.php:59
C:\dvl\Workspace\phpstan-extensions\src\Console\Terminal.php:34
C:\dvl\Workspace\phpstan-extensions\src\ErrorFormatter\SymplifyErrorFormatter.php:82
C:\dvl\Workspace\phpstan-extensions\src\ErrorFormatter\SymplifyErrorFormatter.php:113
C:\dvl\Workspace\phpstan-extensions\src\ErrorFormatter\SymplifyErrorFormatter.php:71
C:\dvl\Workspace\phpstan-extensions\src\ErrorFormatter\SymplifyErrorFormatter.php:49
C:\dvl\Workspace\phpstan-extensions\tests\ErrorFormatter\SymplifyErrorFormatterTest.php:28

ERRORS!
Tests: 5, Assertions: 5, Errors: 1.

```

requires https://github.com/symplify/phpstan-extensions/pull/9