### PR TITLE
Render error identifier when ran verbose

### DIFF
--- a/src/ErrorFormatter/SymplifyErrorFormatter.php
+++ b/src/ErrorFormatter/SymplifyErrorFormatter.php
@@ -136,6 +136,10 @@ final class SymplifyErrorFormatter implements ErrorFormatter
         $itemMessage = sprintf(" - '%s'", $regexMessage);
         $this->writeln($itemMessage);
 
+        if ($this->output?->isVerbose() && $error->getIdentifier() !== null && $error->canBeIgnored()) {
+            $this->writeln(' 🪪 ' . $error->getIdentifier());
+        }
+
         $this->separator();
         $outputStyle->newLine();
     }


### PR DESCRIPTION
PHPStan when ran verbose (-v) displays the [error identifier](https://phpstan.org/error-identifiers). This is very useful when solving errors or choosing to ignore this type of error, either globally or locally

### Global ignore example

In `phpstan.neon`
```neon file="phpstan.neon"
    ignoreErrors:
        - identifier: identical.alwaysFalse
          path: src/ErrorFormatter
```

### Local ignore example

```php
// @phpstan-ignore identical.alwaysFalse
if ('a' === 'b') {
    // test
}
```

Currently Simplify does not support rendering the error identifier, which is what keeps me from fully using it. This PR adds support for rendering the error identifier.

Example output:
`vendor/bin/phpstan analyse --error-format symplify -v`

```
 14/14 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% < 1 sec

 --------------------------------------------------------------------------------------------------------
  src/ErrorFormatter/SymplifyErrorFormatter.php:143
 --------------------------------------------------------------------------------------------------------
  - '#Strict comparison using \=\=\= between 'a' and 'b' will always evaluate to false#'
  🪪 identical.alwaysFalse
 --------------------------------------------------------------------------------------------------------


                                                                                                                
 [ERROR] Found 1 errors                                                                                                                                  
```

`vendor/bin/phpstan analyse --error-format symplify` (without the `-v` verbose flag) has no changes.


For reference, the PHPStan error formatter output with the `-v` verbose flag:

`vendor/bin/phpstan analyse -v`

```
 14/14 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% < 1 sec

 ------ -------------------------------------------------------------------------------- 
  Line   src/ErrorFormatter/SymplifyErrorFormatter.php                                   
 ------ -------------------------------------------------------------------------------- 
  143    Strict comparison using === between 'a' and 'b' will always evaluate to false.  
         🪪  identical.alwaysFalse                                                       
 ------ -------------------------------------------------------------------------------- 


                                                                                                                
 [ERROR] Found 1 error                                                                                          
```
