### PR TITLE
Bump to PHPStan ^2.1.32 with fix ClassConstFetchReturnTypeResolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1.32"
     },
     "require-dev": {
         "illuminate/container": "^11.0",

--- a/rector.php
+++ b/rector.php
@@ -6,7 +6,7 @@ use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
-    ->withPreparedSets(codeQuality: true, deadCode: true, naming: true, privatization: true, earlyReturn: true, codingStyle: true)
+    ->withPreparedSets(deadCode: true, codeQuality: true, codingStyle: true, privatization: true, naming: true, earlyReturn: true)
     ->withRootFiles()
     ->withSkip([
         '*/Source/*',

--- a/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
+++ b/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
@@ -13,14 +13,13 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Symplify\PHPStanExtensions\Exception\ShouldNotHappenException;
 
 final class ClassConstFetchReturnTypeResolver
 {
     public function resolve(MethodReflection $methodReflection, MethodCall $methodCall): ?Type
     {
         if (! isset($methodCall->args[0])) {
-            throw new ShouldNotHappenException('Not supported without argument');
+            return null;
         }
 
         $firstArgOrVariadciPlaceholder = $methodCall->args[0];


### PR DESCRIPTION
@TomasVotruba during try to fix clone type check on rector-src:

- https://github.com/rectorphp/rector-src/pull/7622

I found that the PHPStan 2.1.32 cause issue on running phpstan itself, and it got on `ClassConstFetchReturnTypeResolver`

https://github.com/rectorphp/rector-src/actions/runs/19303603336/job/55204664628?pr=7622#step:5:19

running with verbose got error on this part:

https://github.com/symplify/phpstan-extensions/blob/1af4897b0cf6fba0d9097d62ea6994f3e2e567f9/src/TypeResolver/ClassConstFetchReturnTypeResolver.php#L22-L24

This PR fix it by return null.
